### PR TITLE
EVG-7915 : Allow passing a YAML document to host.create

### DIFF
--- a/parsing.go
+++ b/parsing.go
@@ -60,7 +60,7 @@ func ReadJSONFile(path string, target interface{}) error {
 		return errors.Wrapf(err, "invalid file: %s", path)
 	}
 
-	return errors.Wrapf(ReadYAML(file, target), "problem reading json from '%s'", path)
+	return errors.Wrapf(ReadJSON(file, target), "problem reading json from '%s'", path)
 }
 
 // PrintJSON marshals the data to a pretty-printed (indented) string


### PR DESCRIPTION
fix ReadYAML typo
[EVG-7915 PR ](https://github.com/evergreen-ci/evergreen/pull/3611)
