### PR TITLE
MAKE-1351: add file checksum functions

### DIFF
--- a/checksum.go
+++ b/checksum.go
@@ -1,0 +1,45 @@
+package utility
+
+import (
+	"crypto/md5"
+	"crypto/sha1"
+	"fmt"
+	"hash"
+	"io"
+	"os"
+
+	"github.com/pkg/errors"
+)
+
+// ChecksumFile returns the checksum of a file given by path using the given
+// hash.
+func ChecksumFile(hash hash.Hash, path string) (string, error) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return "", errors.Wrapf(err, "file '%s' does not exist", path)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return "", errors.Wrapf(err, "problem opening '%s'", path)
+	}
+	defer f.Close()
+
+	_, err = io.Copy(hash, f)
+	if err != nil {
+		return "", errors.Wrap(err, "problem hashing contents")
+	}
+
+	return fmt.Sprintf("%x", hash.Sum(nil)), nil
+}
+
+// MD5SumFile is the same as ChecksumFile using MD5 as the checksum.
+func MD5SumFile(path string) (string, error) {
+	out, err := ChecksumFile(md5.New(), path)
+	return out, errors.WithStack(err)
+}
+
+// SHA1SumFile is the same as ChecksumFile using SHA1 as the checksum.
+func SHA1SumFile(path string) (string, error) {
+	out, err := ChecksumFile(sha1.New(), path)
+	return out, errors.WithStack(err)
+}

--- a/checksum_test.go
+++ b/checksum_test.go
@@ -1,0 +1,64 @@
+package utility
+
+import (
+	"crypto"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChecksumFile(t *testing.T) {
+	if usr, _ := user.Current(); usr == nil || usr.Username == "root" {
+		t.Skip("test assumes not root")
+	}
+	_, file, _, _ := runtime.Caller(1)
+
+	for name, hash := range map[string]crypto.Hash{
+		"MD5":    crypto.MD5,
+		"SHA512": crypto.SHA512,
+		"SHA1":   crypto.SHA1,
+		"SHA256": crypto.SHA256,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Run("NoFile", func(t *testing.T) {
+				out, err := ChecksumFile(hash.New(), "")
+				assert.Error(t, err)
+				assert.Zero(t, out)
+			})
+			t.Run("FileIsNotReadable", func(t *testing.T) {
+				out, err := ChecksumFile(hash.New(), "/etc/passwd")
+				assert.Error(t, err)
+				assert.Zero(t, out)
+			})
+			t.Run("FileIsDirectory", func(t *testing.T) {
+				out, err := ChecksumFile(hash.New(), filepath.Dir(file))
+				assert.Error(t, err)
+				assert.Zero(t, out)
+			})
+			t.Run("FileExists", func(t *testing.T) {
+				out, err := ChecksumFile(hash.New(), file)
+				assert.NoError(t, err)
+				assert.NotZero(t, out)
+			})
+		})
+	}
+	t.Run("NilHash", func(t *testing.T) {
+		assert.Panics(t, func() {
+			out, err := ChecksumFile(nil, file)
+			assert.Error(t, err)
+			assert.Zero(t, out)
+		})
+	})
+	t.Run("ChecksumFrontends", func(t *testing.T) {
+		out, err := MD5SumFile(file)
+		assert.NoError(t, err)
+		assert.NotZero(t, out)
+
+		out, err = SHA1SumFile(file)
+		assert.NoError(t, err)
+		assert.NotZero(t, out)
+	})
+}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-1351

This is taken from pail so we can re-use these in the jasper file dependency caching.