### PR TITLE
EVG-8930: make file list builder more usable

### DIFF
--- a/file.go
+++ b/file.go
@@ -93,14 +93,22 @@ type FileMatcher interface {
 }
 
 // AlwaysMatch provides a FileMatcher implementation that will always match a
-// file.
+// file or directory.
 type AlwaysMatch struct{}
 
 // Match always returns true.
 func (m AlwaysMatch) Match(string, os.FileInfo) bool { return true }
 
+// FileFileAlwaysMatch provides a FileMatcher implementation that will always
+// match a file, but not a directory.
+type FileAlwaysMatch struct{}
+
+func (m FileAlwaysMatch) Match(_ string, info os.FileInfo) bool {
+	return !info.IsDir()
+}
+
 // NeverMatch provides a FileMatcher implementation that will never match a
-// file.
+// file or directory.
 type NeverMatch struct{}
 
 // Match always returns false.
@@ -121,10 +129,10 @@ type FileListBuilder struct {
 }
 
 // NewFileListBuilder returns a default FileListBuilder that will match all
-// files within the given directory dir.
+// files (but not directory names) within the given directory dir.
 func NewFileListBuilder(dir string) *FileListBuilder {
 	return &FileListBuilder{
-		Include:    AlwaysMatch{},
+		Include:    FileAlwaysMatch{},
 		Exclude:    NeverMatch{},
 		WorkingDir: dir,
 	}

--- a/file.go
+++ b/file.go
@@ -57,45 +57,109 @@ func WriteFile(path string, data string) error {
 	return errors.WithStack(WriteRawFile(path, []byte(data)))
 }
 
-// fileListBuilder contains the information for building a list of files in the given directory.
+// gitignoreFileMatcher contains the information for building a list of files in the given directory.
 // It adds the files to include in the fileNames array and uses the ignorer to determine if a given
 // file matches and should be added.
-type fileListBuilder struct {
-	fileNames []string
-	ignorer   *ignore.GitIgnore
-	prefix    string
+type gitignoreFileMatcher struct {
+	ignorer *ignore.GitIgnore
+	prefix  string
 }
 
-func (fb *fileListBuilder) walkFunc(path string, info os.FileInfo, err error) error {
+// NewGitignoreFileMatcher returns a FileMatcher that matches the
+// expressions rooted at the given prefix. The expressions should be gitignore
+// ignore expressions: antyhing that would be matched - and therefore ignored by
+// git - is matched.
+func NewGitignoreFileMatcher(prefix string, exprs ...string) (FileMatcher, error) {
+	ignorer, err := ignore.CompileIgnoreLines(exprs...)
 	if err != nil {
-		return errors.Wrapf(err, "Error received by walkFunc for path %s", path)
+		return nil, errors.Wrap(err, "compiling gitignore expressions")
 	}
-	path = strings.TrimPrefix(path, fb.prefix)
-	path = strings.TrimLeft(path, string(os.PathSeparator))
-	if !info.IsDir() && fb.ignorer.MatchesPath(path) {
-		fb.fileNames = append(fb.fileNames, path)
+	m := &gitignoreFileMatcher{
+		ignorer: ignorer,
+		prefix:  prefix,
 	}
+	return m, nil
+}
+
+func (m *gitignoreFileMatcher) Match(file string, info os.FileInfo) bool {
+	file = strings.TrimLeft(strings.TrimPrefix(file, m.prefix), string(os.PathSeparator))
+	return !info.IsDir() && m.ignorer.MatchesPath(file)
+}
+
+// FileMatcher represents a type that can match against files and file
+// information to determine if it should be included.
+type FileMatcher interface {
+	Match(file string, info os.FileInfo) bool
+}
+
+// AlwaysMatch provides a FileMatcher implementation that will always match a
+// file.
+type AlwaysMatch struct{}
+
+// Match always returns true.
+func (m AlwaysMatch) Match(string, os.FileInfo) bool { return true }
+
+// NeverMatch provides a FileMatcher implementation that will never match a
+// file.
+type NeverMatch struct{}
+
+// Match always returns false.
+func (m NeverMatch) Match(string, os.FileInfo) bool { return false }
+
+// FileListBuilder provides options to find files within a directory.
+type FileListBuilder struct {
+	// Include determines which files should be included. This has lower
+	// precedence than the Exclude filter.
+	Include FileMatcher
+	// Exclude determines which files should be excluded from the file list.
+	// This has higher precedence than the Include filter.
+	Exclude FileMatcher
+	// WorkingDir is the base working directory from which to start searching
+	// for files.
+	WorkingDir string
+	files      []string
+}
+
+// NewFileListBuilder returns a default FileListBuilder that will match all
+// files within the given directory dir.
+func NewFileListBuilder(dir string) *FileListBuilder {
+	return &FileListBuilder{
+		Include:    AlwaysMatch{},
+		Exclude:    NeverMatch{},
+		WorkingDir: dir,
+	}
+}
+
+// Build finds all files that pass the include and exclude filters within the
+// working directory. It does not follow symlinks. All files returned are
+// relative to the working directory.
+func (b *FileListBuilder) Build() ([]string, error) {
+	if b.Include == nil {
+		return nil, errors.New("cannot build file list without an include filter")
+	}
+	if err := filepath.Walk(b.WorkingDir, b.visitPath); err != nil {
+		return nil, errors.Wrap(err, "building file list")
+	}
+
+	return b.files, nil
+}
+
+func (b *FileListBuilder) visitPath(path string, info os.FileInfo, err error) error {
+	if err != nil {
+		return errors.Wrapf(err, "path '%s'", path)
+	}
+
+	if b.Exclude != nil && b.Exclude.Match(path, info) {
+		return nil
+	}
+
+	if b.Include == nil || !b.Include.Match(path, info) {
+		return nil
+	}
+
+	// All accumulated paths are relative to the working directory.
+	toAdd := strings.TrimPrefix(strings.TrimPrefix(path, b.WorkingDir), string(os.PathSeparator))
+	b.files = append(b.files, toAdd)
+
 	return nil
-}
-
-// BuildFileList returns a list of files that match the given list of expressions
-// rooted at the given startPath. The expressions correspond to gitignore ignore
-// expressions: anything that would be matched - and therefore ignored by git - is included
-// in the returned list of file paths. BuildFileList does not follow symlinks as
-// it uses filpath.Walk, which does not follow symlinks.
-func BuildFileList(startPath string, expressions ...string) ([]string, error) {
-	ignorer, err := ignore.CompileIgnoreLines(expressions...)
-	if err != nil {
-		return nil, err
-	}
-	fb := &fileListBuilder{
-		fileNames: []string{},
-		ignorer:   ignorer,
-		prefix:    startPath,
-	}
-	err = filepath.Walk(startPath, fb.walkFunc)
-	if err != nil {
-		return nil, err
-	}
-	return fb.fileNames, nil
 }

--- a/file_test.go
+++ b/file_test.go
@@ -24,25 +24,32 @@ func TestFile(t *testing.T) {
 	})
 }
 
-func TestBuildFileList(t *testing.T) {
+func TestFileListBuilder(t *testing.T) {
 	t.Run("DoesNotPanicForMissingRoot", func(t *testing.T) {
 		assert.NotPanics(t, func() {
-			list, err := BuildFileList("this/path/does/not/exist", "*")
+			dir := "this/path/does/not/exist"
+			m, err := NewGitignoreFileMatcher(dir, "*")
+			require.NoError(t, err)
+			b := FileListBuilder{
+				WorkingDir: dir,
+				Include:    m,
+			}
+			files, err := b.Build()
 			require.Error(t, err)
-			assert.Empty(t, list)
+			assert.Empty(t, files)
 		})
 	})
 
-	wd, err := ioutil.TempDir("", t.Name())
-	require.NoError(t, err, "error getting working directory")
+	tmpDir, err := ioutil.TempDir("", t.Name())
+	require.NoError(t, err)
 	defer func() {
-		assert.NoError(t, os.RemoveAll(wd))
+		assert.NoError(t, os.RemoveAll(tmpDir))
 	}()
 
-	fnames := []string{
+	fileNames := []string{
 		"testFile1",
 		"testFile2",
-		"testFile.go",
+		"testFile1.go",
 		"testFile2.go",
 		"testFile3.yml",
 		"built.yml",
@@ -53,86 +60,126 @@ func TestBuildFileList(t *testing.T) {
 		"dir1",
 		"dir2",
 	}
-	// create all the files in the current directory
-	for _, fname := range fnames {
-		f, err := os.Create(filepath.Join(wd, fname))
+
+	for _, fileName := range fileNames {
+		f, err := os.Create(filepath.Join(tmpDir, fileName))
 		require.NoError(t, err, "error creating test file")
 		require.NoError(t, f.Close(), "error closing test file")
 	}
 
-	// create all the files in the sub directories
 	for _, dirName := range dirNames {
-		err := os.Mkdir(filepath.Join(wd, dirName), 0777)
+		err := os.Mkdir(filepath.Join(tmpDir, dirName), 0777)
 		require.NoError(t, err, "error creating test directory")
-		for _, fname := range fnames {
-			path := filepath.Join(wd, dirName, fname)
+		for _, fileName := range fileNames {
+			path := filepath.Join(tmpDir, dirName, fileName)
 			f, err := os.Create(path)
 			require.NoError(t, err, "error creating test file")
 			require.NoError(t, f.Close(), "error closing test file")
 		}
 	}
-	defer func() {
-		require.NoError(t, os.RemoveAll(wd), "error removing test directory")
-	}()
 
-	t.Run("MatchesOneFileName", func(t *testing.T) {
-		files, err := BuildFileList(wd, fnames[0])
-		require.NoError(t, err)
-		assert.Contains(t, files[0], fnames[0])
-		for i := 1; i < len(fnames); i++ {
-			assert.NotContains(t, files, fnames[i])
-		}
-	})
-	t.Run("MatchesAllFilesWithPrefix", func(t *testing.T) {
-		files, err := BuildFileList(wd, "/testFile*")
-		require.NoError(t, err)
-		for i, fname := range fnames {
-			if i <= 4 {
-				assert.Contains(t, files, fname)
-			} else {
-				assert.NotContains(t, files, fname)
-			}
-		}
-	})
-	t.Run("MatchesAllFilesWithSuffix", func(t *testing.T) {
-		files, err := BuildFileList(wd, "/*.go")
-		require.NoError(t, err)
-		for i, fname := range fnames {
-			if i == 2 || i == 3 || i == 6 {
-				assert.Contains(t, files, fname)
-			} else {
-				assert.NotContains(t, files, fname)
-			}
-		}
-	})
-	t.Run("MatchesAllFilesInSubdirectoryWithSuffix", func(t *testing.T) {
-		files, err := BuildFileList(wd, "/dir1/*.go")
-		require.NoError(t, err)
-		for i, fname := range fnames {
-			path := filepath.Join("dir1", fname)
-			if i == 2 || i == 3 || i == 6 {
-				assert.Contains(t, files, path)
-				assert.NotContains(t, files, fname)
-			} else {
-				assert.NotContains(t, files, path)
-				assert.NotContains(t, files, fname)
-			}
-		}
-	})
-	t.Run("MatchesAllFilesInWildcardSubdirectoryWithSuffix", func(t *testing.T) {
-		files, err := BuildFileList(wd, "/*/*.go")
-		require.NoError(t, err)
-		for i, fname := range fnames {
-			for _, dirName := range dirNames {
-				path := filepath.Join(dirName, fname)
-				if i == 2 || i == 3 || i == 6 {
-					assert.Contains(t, files, path)
-					assert.NotContains(t, files, fname)
-				} else {
-					assert.NotContains(t, files, path)
-					assert.NotContains(t, files, fname)
+	t.Run("GitignoreFileBuilder", func(t *testing.T) {
+		for testName, testCase := range map[string]struct {
+			includeExprs []string
+			excludeExprs []string
+			expected     []string
+		}{
+			"MatchesOneFileName": {
+				includeExprs: []string{"testFile1"},
+				expected: []string{
+					"testFile1",
+					filepath.Join("dir1", "testFile1"),
+					filepath.Join("dir2", "testFile1"),
+				},
+			},
+			"MatchesOneFileWhenSubdirectoriesExcluded": {
+				includeExprs: []string{"testFile1"},
+				excludeExprs: []string{"/*/testFile1"},
+				expected:     []string{"testFile1"},
+			},
+			"MatchesAllFilesWithPrefix": {
+				includeExprs: []string{"/testFile*"},
+				expected: []string{
+					"testFile1",
+					"testFile2",
+					"testFile1.go",
+					"testFile2.go",
+					"testFile3.yml",
+				},
+			},
+			"MatchesAllFilesWithPrefixExcludingSuffix": {
+				includeExprs: []string{"/testFile*"},
+				excludeExprs: []string{"/*.go"},
+				expected: []string{
+					"testFile1",
+					"testFile2",
+					"testFile3.yml",
+				},
+			},
+			"MatchesAllFilesWithSuffix": {
+				includeExprs: []string{"/*.go"},
+				expected: []string{
+					"testFile1.go",
+					"testFile2.go",
+					"built.go",
+				},
+			},
+			"MatchesAllFilesWithSuffixExcludingPrefix": {
+				includeExprs: []string{"/*.go"},
+				excludeExprs: []string{"/built*"},
+				expected: []string{
+					"testFile1.go",
+					"testFile2.go",
+				},
+			},
+			"MatchesAllFilesInSubdirectoryWithSuffix": {
+				includeExprs: []string{"/dir1/*.go"},
+				expected: []string{
+					filepath.Join("dir1", "testFile1.go"),
+					filepath.Join("dir1", "testFile2.go"),
+					filepath.Join("dir1", "built.go"),
+				},
+			},
+			"MatchesAllFilesInWildcardSubdirectoryWithSuffix": {
+				includeExprs: []string{"/*/*.go"},
+				expected: []string{
+					filepath.Join("dir1", "testFile1.go"),
+					filepath.Join("dir1", "testFile2.go"),
+					filepath.Join("dir1", "built.go"),
+					filepath.Join("dir2", "testFile1.go"),
+					filepath.Join("dir2", "testFile2.go"),
+					filepath.Join("dir2", "built.go"),
+				},
+			},
+			"MatchesAllFilesInWildcardSubdirectoryWithSuffixExcludingPrefix": {
+				includeExprs: []string{"/*/*.go"},
+				excludeExprs: []string{"/*/built*"},
+				expected: []string{
+					filepath.Join("dir1", "testFile1.go"),
+					filepath.Join("dir1", "testFile2.go"),
+					filepath.Join("dir2", "testFile1.go"),
+					filepath.Join("dir2", "testFile2.go"),
+				},
+			},
+		} {
+			t.Run(testName, func(t *testing.T) {
+				include, err := NewGitignoreFileMatcher(tmpDir, testCase.includeExprs...)
+				require.NoError(t, err)
+				var exclude FileMatcher
+				if len(testCase.excludeExprs) != 0 {
+					exclude, err = NewGitignoreFileMatcher(tmpDir, testCase.excludeExprs...)
+					require.NoError(t, err)
 				}
-			}
+				b := FileListBuilder{
+					WorkingDir: tmpDir,
+					Include:    include,
+					Exclude:    exclude,
+				}
+
+				files, err := b.Build()
+				require.NoError(t, err)
+				assert.ElementsMatch(t, testCase.expected, files)
+			})
 		}
 	})
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-8930

`BuildFileList` finds files within a directory but assumed that the implementation would always be based on gitignore-style file matching. This one is meant to allow alternative include filter implementations aside from gitignore. It also provides support for file exclusion filters.

* Refactor `BuildFileList` into `FileListBuilder` to allow include/exclude file filters.
* Export gitignore-based file matcher.