### PR TITLE
EVG-14733: move retry functionality from Evergreen

### DIFF
--- a/http.go
+++ b/http.go
@@ -358,3 +358,12 @@ func RetryRequest(ctx context.Context, r *http.Request, maxAttempts int, minBack
 	}
 	return nil, errors.Errorf("Failed to make request after %d attempts", maxAttempts)
 }
+
+// RehttpDelay returns the function that generates the exponential backoff delay
+// between retried HTTP requests.
+func RehttpDelay(opts RetryOptions) HTTPDelayFunction {
+	backoff := getBackoff(opts)
+	return func(index int, req *http.Request, resp *http.Response, err error) time.Duration {
+		return backoff.ForAttempt(float64(index))
+	}
+}

--- a/http.go
+++ b/http.go
@@ -359,9 +359,9 @@ func RetryRequest(ctx context.Context, r *http.Request, maxAttempts int, minBack
 	return nil, errors.Errorf("Failed to make request after %d attempts", maxAttempts)
 }
 
-// RehttpDelay returns the function that generates the exponential backoff delay
-// between retried HTTP requests.
-func RehttpDelay(opts RetryOptions) HTTPDelayFunction {
+// RetryHTTPDelay returns the function that generates the exponential backoff
+// delay between retried HTTP requests.
+func RetryHTTPDelay(opts RetryOptions) HTTPDelayFunction {
 	backoff := getBackoff(opts)
 	return func(index int, req *http.Request, resp *http.Response, err error) time.Duration {
 		return backoff.ForAttempt(float64(index))

--- a/retry.go
+++ b/retry.go
@@ -14,15 +14,17 @@ func init() {
 	rand.Seed(time.Now().Unix())
 }
 
-// RetriableFunc is any function that takes no parameters and returns only
-// an error interface. These functions can be used with util.Retry.
-type RetriableFunc func() (bool, error)
+// RetriableFunc is any function that takes no parameters and returns an error,
+// and whether or not the operation can be retried. These functions can be used
+// with util.Retry.
+type RetriableFunc func() (canRetry bool, err error)
 
 // Retry provides a mechanism to retry an operation with exponential backoff
 // and jitter.
 func Retry(ctx context.Context, op RetriableFunc, opts RetryOptions) error {
 	backoff := getBackoff(opts)
 	timer := time.NewTimer(0)
+	defer timer.Stop()
 	var attempt int
 
 	for {

--- a/retry.go
+++ b/retry.go
@@ -76,7 +76,7 @@ type RetryOptions struct {
 // It will set min to 100ms if not set.
 // It will set max to (min * 2^attempts) if not set.
 // It will set attempts to 1 if not set.
-func (o *RetryOptions) Validate() error {
+func (o *RetryOptions) Validate() {
 	if o.MaxAttempts <= 0 {
 		o.MaxAttempts = 1
 	}
@@ -89,8 +89,6 @@ func (o *RetryOptions) Validate() error {
 	if o.MaxDelay <= 0 {
 		o.MaxDelay = time.Duration(float64(o.MinDelay) * math.Pow(backoffFactor, float64(o.MaxAttempts)))
 	}
-
-	return nil
 }
 
 // backoffFactor is the exponential backoff factor.

--- a/retry.go
+++ b/retry.go
@@ -1,0 +1,97 @@
+package utility
+
+import (
+	"context"
+	"math"
+	"math/rand"
+	"time"
+
+	"github.com/jpillora/backoff"
+	"github.com/pkg/errors"
+)
+
+func init() {
+	rand.Seed(time.Now().Unix())
+}
+
+// RetriableFunc is any function that takes no parameters and returns only
+// an error interface. These functions can be used with util.Retry.
+type RetriableFunc func() (bool, error)
+
+// Retry provides a mechanism to retry an operation with exponential backoff
+// and jitter.
+func Retry(ctx context.Context, op RetriableFunc, opts RetryOptions) error {
+	backoff := getBackoff(opts)
+	timer := time.NewTimer(0)
+	var attempt int
+
+	for {
+		select {
+		case <-ctx.Done():
+			return errors.Errorf("context canceled after %d attempts", attempt)
+		case <-timer.C:
+			shouldRetry, err := op()
+			if err == nil {
+				return nil
+			}
+			if !shouldRetry {
+				return err
+			}
+
+			attempt++
+			if attempt == opts.MaxAttempts {
+				return errors.Wrapf(err, "after %d attempts, operation failed", opts.MaxAttempts)
+			}
+			timer.Reset(backoff.Duration())
+		}
+	}
+}
+
+func getBackoff(opts RetryOptions) *backoff.Backoff {
+	opts.Validate()
+	return &backoff.Backoff{
+		Min:    opts.MinDelay,
+		Max:    opts.MaxDelay,
+		Factor: float64(backoffFactor),
+		Jitter: true,
+	}
+}
+
+// RetryOptions defines the policy for retrying an operation. This is typically
+// used with retries that use exponential backoff.
+type RetryOptions struct {
+	// MaxAttempts is the total number of times the operation can be attempted.
+	// By default, it is 1 (i.e. no retries).
+	MaxAttempts int
+	// MinDelay is the minimum delay between operation attempts. By default, it
+	// is 100ms.
+	MinDelay time.Duration
+	// MaxDelay is the maximum delay between operation attempts. By default, it
+	// is (MinDelay * 2^MaxAttempts).
+	MaxDelay time.Duration
+}
+
+// Validate sets defaults for unspecified or invalid options.
+//
+// It will set min to 100ms if not set.
+// It will set max to (min * 2^attempts) if not set.
+// It will set attempts to 1 if not set.
+func (o *RetryOptions) Validate() error {
+	if o.MaxAttempts <= 0 {
+		o.MaxAttempts = 1
+	}
+
+	const floor = 100 * time.Millisecond
+	if o.MinDelay < floor {
+		o.MinDelay = floor
+	}
+
+	if o.MaxDelay <= 0 {
+		o.MaxDelay = time.Duration(float64(o.MinDelay) * math.Pow(backoffFactor, float64(o.MaxAttempts)))
+	}
+
+	return nil
+}
+
+// backoffFactor is the exponential backoff factor.
+const backoffFactor = 2

--- a/retry.go
+++ b/retry.go
@@ -49,6 +49,9 @@ func Retry(ctx context.Context, op RetriableFunc, opts RetryOptions) error {
 	}
 }
 
+// backoffFactor is the exponential backoff factor.
+const backoffFactor = 2
+
 func getBackoff(opts RetryOptions) *backoff.Backoff {
 	opts.Validate()
 	return &backoff.Backoff{
@@ -92,6 +95,3 @@ func (o *RetryOptions) Validate() {
 		o.MaxDelay = time.Duration(float64(o.MinDelay) * math.Pow(backoffFactor, float64(o.MaxAttempts)))
 	}
 }
-
-// backoffFactor is the exponential backoff factor.
-const backoffFactor = 2

--- a/retry_test.go
+++ b/retry_test.go
@@ -1,0 +1,77 @@
+package utility
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetry(t *testing.T) {
+	const maxAttempts = 5
+	const minDelay = 10 * time.Millisecond
+
+	t.Run("ErrorsWithOperationThatNeverSucceeds", func(t *testing.T) {
+		failingFunc := func() (bool, error) {
+			return true, errors.New("something went wrong")
+		}
+
+		start := time.Now()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		err := Retry(ctx, failingFunc, RetryOptions{MaxAttempts: maxAttempts, MinDelay: minDelay})
+		end := time.Now()
+		require.Error(t, err, "retrying an operation that never succeeds should error")
+		assert.True(t, end.After(start.Add((maxAttempts-1)*minDelay)))
+	})
+	t.Run("SucceedsWithOperationThatSucceedsAfterSomeAttempts", func(t *testing.T) {
+		const triesTillPass = 2
+
+		tryCounter := triesTillPass
+		retryPassingFunc := func() (bool, error) {
+			tryCounter--
+			if tryCounter <= 0 {
+				return false, nil
+			}
+			return true, errors.New("something went wrong")
+		}
+
+		opts := RetryOptions{
+			MaxAttempts: maxAttempts,
+			MinDelay:    minDelay,
+		}
+		opts.Validate()
+		backoff := getBackoff(opts)
+
+		start := time.Now()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		err := Retry(ctx, retryPassingFunc, opts)
+		end := time.Now()
+		require.NoError(t, err, "operation should have succeeded after some failed attempts")
+
+		assert.True(t, end.After(start.Add((triesTillPass-1)*minDelay)))
+		assert.True(t, end.Before(start.Add(backoff.Max)))
+	})
+	t.Run("NonRetryableErrorFails", func(t *testing.T) {
+		failingFuncNoRetry := func() (bool, error) {
+			return false, errors.New("something went wrong")
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		err := Retry(ctx, failingFuncNoRetry, RetryOptions{MaxAttempts: maxAttempts, MinDelay: minDelay})
+		assert.Error(t, err)
+	})
+	t.Run("DoesNotDelayFirstAttempt", func(t *testing.T) {
+		now := time.Now()
+		noop := func() (bool, error) {
+			return false, nil
+		}
+		require.NoError(t, Retry(context.Background(), noop, RetryOptions{MaxAttempts: 10, MinDelay: time.Second, MaxDelay: time.Second}))
+		require.True(t, time.Since(now) < time.Millisecond)
+	})
+}

--- a/slice_test.go
+++ b/slice_test.go
@@ -65,12 +65,12 @@ func TestStringSliceSymmetricDifference(t *testing.T) {
 	assert.Len(t, onlyB, 2)
 
 	onlyA, onlyB = StringSliceSymmetricDifference(a, a)
-	assert.Equal(t, []string{}, onlyA)
-	assert.Equal(t, []string{}, onlyB)
+	assert.Zero(t, onlyA)
+	assert.Zero(t, onlyB)
 
 	empty1, empty2 := StringSliceSymmetricDifference([]string{}, []string{})
-	assert.Equal(t, []string{}, empty1)
-	assert.Equal(t, []string{}, empty2)
+	assert.Zero(t, empty1)
+	assert.Zero(t, empty2)
 }
 
 func TestGetSetDifference(t *testing.T) {


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14733

* Move the logic to perform [retrying with exponential backoff + jitter from Evergreen's util package](https://github.com/evergreen-ci/evergreen/blob/main/util/retry.go) to here. I tidied it up a bit, so it doesn't match the util package exactly.
* Fix an unrelated test that checked for an empty slice instead of nil slice.