### PR TITLE
EVG-15242: Mock HTTP Handler implementation

### DIFF
--- a/http.go
+++ b/http.go
@@ -393,7 +393,7 @@ func NewMockHandler() *MockHandler { return &MockHandler{} }
 // URLs are recorded and the customizable header, body, and status code are all
 // written to the http.ResponseWriter. If there is an error when writing to the
 // http.ResponseWriter, a 500 status code is returned to the requester;
-// WriteError (see below) returns the most recent error.
+// WriteError (see below) returns the most recent write error.
 func (h *MockHandler) ServerHTTP(w http.ResponseWriter, r *http.Request) {
 	h.Mu.Lock()
 	defer h.Mu.Unlock()

--- a/http.go
+++ b/http.go
@@ -392,7 +392,7 @@ func NewMockHandler() *MockHandler { return &MockHandler{} }
 // ServeHTTP is a thread-safe handler for mocking HTTP responses. The request
 // URLs are recorded and the customizable header, body, and status code are all
 // written to the http.ResponseWriter.
-// WriteError (see below) returns the most recent write error, if any.
+// GetWriteError (see below) returns the most recent write error, if any.
 func (h *MockHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.Mu.Lock()
 	defer h.Mu.Unlock()
@@ -417,6 +417,6 @@ func (h *MockHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// WriteError returns the most recent error from writing to the
+// GetWriteError returns the most recent error from writing to the
 // http.ResponseWriter.
-func (h *MockHandler) WriteError() error { return h.writeError }
+func (h *MockHandler) GetWriteError() error { return h.writeError }

--- a/http_test.go
+++ b/http_test.go
@@ -111,7 +111,7 @@ func TestMockHandler(t *testing.T) {
 	client := server.Client()
 
 	t.Run("Serve", func(t *testing.T) {
-		url := server.URL + "/example"
+		urlString := server.URL + "/example"
 		handler.Header = map[string][]string{
 			"header1": []string{"header1"},
 			"header2": []string{"header1", "header2"},
@@ -119,10 +119,12 @@ func TestMockHandler(t *testing.T) {
 		handler.Body = []byte("some body")
 		handler.StatusCode = http.StatusOK
 
-		req, err := http.NewRequest(http.MethodGet, url, nil)
+		req, err := http.NewRequest(http.MethodGet, urlString, nil)
+		require.NoError(t, err)
 		resp, err := client.Do(req)
 		require.NoError(t, err)
 
+		assert.Len(t, handler.Calls, 1)
 		for key, values := range handler.Header {
 			assert.Equal(t, values, resp.Header.Values(key))
 		}
@@ -132,17 +134,19 @@ func TestMockHandler(t *testing.T) {
 		assert.Equal(t, handler.Body, body)
 		assert.NoError(t, handler.WriteError())
 
-		url = server.URL + "/example2"
+		urlString = server.URL + "/example2"
 		handler.Header = map[string][]string{
 			"header1": []string{"header1"},
 		}
 		handler.Body = []byte("example not found")
 		handler.StatusCode = http.StatusNotFound
 
-		req, err = http.NewRequest(http.MethodGet, url, nil)
+		req, err = http.NewRequest(http.MethodGet, urlString, nil)
+		require.NoError(t, err)
 		resp, err = client.Do(req)
 		require.NoError(t, err)
 
+		assert.Len(t, handler.Calls, 2)
 		for key, values := range handler.Header {
 			assert.Equal(t, values, resp.Header.Values(key))
 		}

--- a/http_test.go
+++ b/http_test.go
@@ -1,8 +1,10 @@
 package utility
 
 import (
+	"io"
 	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -99,5 +101,55 @@ func TestRetryableOauthClient(t *testing.T) {
 		assert.NotNil(t, resp)
 		assert.Equal(t, 6, transport.count)
 		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	})
+}
+
+func TestMockHandler(t *testing.T) {
+	handler := NewMockHandler()
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	client := server.Client()
+
+	t.Run("Serve", func(t *testing.T) {
+		url := server.URL + "/example"
+		handler.Header = map[string][]string{
+			"header1": []string{"header1"},
+			"header2": []string{"header1", "header2"},
+		}
+		handler.Body = []byte("some body")
+		handler.StatusCode = http.StatusOK
+
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+
+		for key, values := range handler.Header {
+			assert.Equal(t, values, resp.Header.Values(key))
+		}
+		assert.Equal(t, handler.StatusCode, resp.StatusCode)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Equal(t, handler.Body, body)
+		assert.NoError(t, handler.WriteError())
+
+		url = server.URL + "/example2"
+		handler.Header = map[string][]string{
+			"header1": []string{"header1"},
+		}
+		handler.Body = []byte("example not found")
+		handler.StatusCode = http.StatusNotFound
+
+		req, err = http.NewRequest(http.MethodGet, url, nil)
+		resp, err = client.Do(req)
+		require.NoError(t, err)
+
+		for key, values := range handler.Header {
+			assert.Equal(t, values, resp.Header.Values(key))
+		}
+		assert.Equal(t, handler.StatusCode, resp.StatusCode)
+		body, err = io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Equal(t, handler.Body, body)
+		assert.NoError(t, handler.WriteError())
 	})
 }

--- a/http_test.go
+++ b/http_test.go
@@ -132,7 +132,7 @@ func TestMockHandler(t *testing.T) {
 		body, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 		assert.Equal(t, handler.Body, body)
-		assert.NoError(t, handler.WriteError())
+		assert.NoError(t, handler.GetWriteError())
 
 		urlString = server.URL + "/example2"
 		handler.Header = map[string][]string{
@@ -154,6 +154,6 @@ func TestMockHandler(t *testing.T) {
 		body, err = io.ReadAll(resp.Body)
 		require.NoError(t, err)
 		assert.Equal(t, handler.Body, body)
-		assert.NoError(t, handler.WriteError())
+		assert.NoError(t, handler.GetWriteError())
 	})
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-15242

This is a convenience implementation of the `http.Handler` interface for mock HTTP servers. Mostly will be used with `httptest.NewServer`.