### PR TITLE
EVG-16443: return context error when retry exits early

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -30,7 +30,7 @@ func Retry(ctx context.Context, op RetriableFunc, opts RetryOptions) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return errors.Errorf("context canceled after %d attempts", attempt)
+			return errors.Wrapf(ctx.Err(), "context canceled after %d attempts", attempt)
 		case <-timer.C:
 			shouldRetry, err := op()
 			if err == nil {


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16443

This makes it easier to check the `errors.Cause` chain for a particular context error.