### PR TITLE
EVG-17128, EVG-16930: port over more string slice methods from Evergreen and deprecate Goreleaser

### DIFF
--- a/makefile
+++ b/makefile
@@ -62,7 +62,7 @@ $(shell mkdir -p $(buildDir))
 
 # start lint setup targets
 $(buildDir)/golangci-lint:
-	@curl --retry 10 --retry-max-time 60 -sSfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(buildDir) v1.40.0 >/dev/null 2>&1
+	@curl --retry 10 --retry-max-time 60 -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(buildDir) v1.40.0 >/dev/null 2>&1
 $(buildDir)/run-linter: cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
 	@$(gobin) build -o $@ $<
 # end lint setup targets

--- a/slice.go
+++ b/slice.go
@@ -1,6 +1,7 @@
 package utility
 
 import (
+	"regexp"
 	"sort"
 	"strings"
 )
@@ -84,7 +85,7 @@ func SplitCommas(originals []string) []string {
 	return splitted
 }
 
-// GetSetDifference returns the elements in A that are not in B
+// GetSetDifference returns the elements in A that are not in B.
 func GetSetDifference(a, b []string) []string {
 	setB := make(map[string]struct{})
 	setDifference := make(map[string]struct{})
@@ -118,4 +119,16 @@ func IndexOf(a []string, toFind string) int {
 		return i
 	}
 	return -1
+}
+
+// StringMatchesAnyRegex determines if the string item matches any regex in
+// the slice.
+func StringMatchesAnyRegex(item string, regexps []string) bool {
+	for _, re := range regexps {
+		matched, err := regexp.MatchString(re, item)
+		if err == nil && matched {
+			return true
+		}
+	}
+	return false
 }

--- a/slice_test.go
+++ b/slice_test.go
@@ -94,3 +94,11 @@ func TestIndexOf(t *testing.T) {
 	assert.Equal(t, -1, IndexOf([]string{"a", "b", "c", "d", "e"}, "1"))
 	assert.Equal(t, -1, IndexOf([]string{"a", "b", "c", "d", "e"}, "æ"))
 }
+
+func TestStringMatchesAnyRegex(t *testing.T) {
+	domains := []string{".*.corp.mongodb.com", "https://something.mongodb.com"}
+	assert.Equal(t, true, StringMatchesAnyRegex("https://patch-analysis-ui.server-tig.staging.corp.mongodb.com", domains))
+	assert.Equal(t, true, StringMatchesAnyRegex("https://something.mongodb.com", domains))
+	assert.Equal(t, false, StringMatchesAnyRegex("corp.mongodb.com", domains))
+	assert.Equal(t, false, StringMatchesAnyRegex("https://something-else.mongodb.com", domains))
+}


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17128

* Ported over another [string slice helper function](https://github.com/evergreen-ci/evergreen/blob/d12940c1609c7e47d27c9a1fddf7ee2972a743a2/util/strings.go#L99-L108) from Evergreen.
* Switch the linter download away from Goreleaser for [EVG-16930](https://jira.mongodb.org/browse/EVG-16930).