### PR TITLE
EVG-16911: migrate hashing helper from Cocoa

### DIFF
--- a/hash.go
+++ b/hash.go
@@ -1,0 +1,42 @@
+package utility
+
+import (
+	"crypto/md5"
+	"crypto/sha1"
+	"crypto/sha256"
+	"fmt"
+	"hash"
+	"io"
+)
+
+// Hash is a wrapper around a hashing algorithm.
+type Hash struct {
+	hash.Hash
+}
+
+// NewMD5Hash returns a Hash that uses the MD5 algorithm.
+func NewMD5Hash() Hash {
+	return Hash{Hash: md5.New()}
+}
+
+// NewSHA1Hash returns a Hash that uses the SHA1 algorithm.
+func NewSHA1Hash() Hash {
+	return Hash{Hash: sha1.New()}
+}
+
+// NewSHA256Hash returns a Hash that uses the SHA256 algorithm.
+func NewSHA256Hash() Hash {
+	return Hash{Hash: sha256.New()}
+}
+
+// Add adds data to the hasher.
+func (h Hash) Add(data string) {
+	// The hash.Hash interface says the io.Writer will never return an error, so
+	// the returned error can be squashed.
+	_, _ = io.WriteString(h, data)
+}
+
+// Sum returns the hash sum of the accumulated data.
+func (h Hash) Sum() string {
+	return fmt.Sprintf("%x", h.Hash.Sum(nil))
+}

--- a/hash_test.go
+++ b/hash_test.go
@@ -1,0 +1,54 @@
+package utility
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHash(t *testing.T) {
+	for hashName, makeHash := range map[string]func() Hash{
+		"MD5":    NewMD5Hash,
+		"SHA1":   NewSHA1Hash,
+		"SHA256": NewSHA256Hash,
+	} {
+		t.Run(hashName, func(t *testing.T) {
+			for tName, tCase := range map[string]func(t *testing.T, makeHash func() Hash){
+				"AddingDataModifiesSum": func(t *testing.T, makeHash func() Hash) {
+					h := makeHash()
+					h.Add("foo")
+					s0 := h.Sum()
+					h.Add("bar")
+					assert.NotEqual(t, s0, h.Sum())
+				},
+				"AddingSameValuesInDifferentOrderReturnsDifferentSum": func(t *testing.T, makeHash func() Hash) {
+					h0 := makeHash()
+					h0.Add("foo")
+					h0.Add("bar")
+					h1 := makeHash()
+					h1.Add("bar")
+					h1.Add("foo")
+					assert.NotEqual(t, h0.Sum(), h1.Sum())
+				},
+				"SumSucceedsForNoData": func(t *testing.T, makeHash func() Hash) {
+					assert.NotPanics(t, func() {
+						makeHash().Sum()
+					})
+				},
+				"SumReturnsConsistentValueForSameInput": func(t *testing.T, makeHash func() Hash) {
+					h0 := makeHash()
+					h0.Add("foo")
+					h0.Add("bar")
+					h1 := makeHash()
+					h1.Add("foo")
+					h1.Add("bar")
+					assert.Equal(t, h0.Sum(), h1.Sum())
+				},
+			} {
+				t.Run(tName, func(t *testing.T) {
+					tCase(t, makeHash)
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16911

This basically just lifts [the code straight from Cocoa](https://github.com/evergreen-ci/cocoa/blob/9c40afd9b130ff985d1f320544c5c04353016eca/ecs_pod_creator.go#L399-L418) and puts it in the common helper library since Evergreen will need similar logic.

