### PR TITLE
EVG-17046: move thread-safe buffer from Jasper to utility

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -1,0 +1,41 @@
+package utility
+
+import (
+	"bytes"
+	"sync"
+)
+
+// MakeSafeBuffer returns a thread-safe Read/Write closer that wraps an existing
+// bytes buffer.
+func MakeSafeBuffer(b bytes.Buffer) *SafeBuffer { return &SafeBuffer{buffer: b} }
+
+// SafeBuffer provides a thread-safe in-memory buffer.
+type SafeBuffer struct {
+	buffer bytes.Buffer
+	sync.RWMutex
+}
+
+// Read performs a thread-safe in-memory read.
+func (b *SafeBuffer) Read(p []byte) (n int, err error) {
+	b.RLock()
+	defer b.RUnlock()
+	return b.buffer.Read(p)
+}
+
+// Write performs a thread-safe in-memory write.
+func (b *SafeBuffer) Write(p []byte) (n int, err error) {
+	b.Lock()
+	defer b.Unlock()
+	return b.buffer.Write(p)
+}
+
+// String returns the in-memory buffer contents as a string in a thread-safe
+// manner.
+func (b *SafeBuffer) String() string {
+	b.RLock()
+	defer b.RUnlock()
+	return b.buffer.String()
+}
+
+// Close is a no-op to satisfy the closer interface.
+func (b *SafeBuffer) Close() error { return nil }


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17046

I'm moving [a useful helper type to wrap `bytes.Buffer`](https://github.com/mongodb/jasper/blob/5925eb396fb86e4009554bed4fa5592bbc7f2ee3/util/buffer.go#L9) out of Jasper and into the general-purpose utility module since it's a miscellaneous and multi-purpose convenience feature. Going to actually use it in Evergreen + update usages in Jasper once this is merged.