### PR TITLE
EVG-19189 make base client configurable

### DIFF
--- a/http.go
+++ b/http.go
@@ -14,12 +14,12 @@ import (
 	"golang.org/x/oauth2"
 )
 
-const HttpClientTimeout = 5 * time.Minute
+const httpClientTimeout = 5 * time.Minute
 
 var httpClientPool *sync.Pool
 
 func init() {
-	InitHTTPPool(newBaseConfiguredHttpClient)
+	InitHTTPPool(NewBaseConfiguredHttpClient)
 }
 
 func InitHTTPPool(clientFactory func() *http.Client) {
@@ -28,14 +28,14 @@ func InitHTTPPool(clientFactory func() *http.Client) {
 	}
 }
 
-func newBaseConfiguredHttpClient() *http.Client {
+func NewBaseConfiguredHttpClient() *http.Client {
 	return &http.Client{
-		Timeout:   HttpClientTimeout,
-		Transport: NewConfiguredBaseTransport(),
+		Timeout:   httpClientTimeout,
+		Transport: newConfiguredBaseTransport(),
 	}
 }
 
-func NewConfiguredBaseTransport() *http.Transport {
+func newConfiguredBaseTransport() *http.Transport {
 	return &http.Transport{
 		TLSClientConfig:     &tls.Config{},
 		Proxy:               http.ProxyFromEnvironment,
@@ -71,7 +71,7 @@ func GetHTTPClient() *http.Client { return httpClientPool.Get().(*http.Client) }
 // PutHTTPClient returns the client to the pool, automatically
 // reconfiguring the transport.
 func PutHTTPClient(c *http.Client) {
-	c.Timeout = HttpClientTimeout
+	c.Timeout = httpClientTimeout
 
 	switch transport := c.Transport.(type) {
 	case *http.Transport:
@@ -86,7 +86,7 @@ func PutHTTPClient(c *http.Client) {
 		PutHTTPClient(c)
 		return
 	default:
-		c.Transport = NewConfiguredBaseTransport()
+		c.Transport = newConfiguredBaseTransport()
 	}
 
 	httpClientPool.Put(c)

--- a/http_test.go
+++ b/http_test.go
@@ -31,7 +31,7 @@ func TestPooledHTTPClient(t *testing.T) {
 		assert.False(t, cl2.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify)
 	})
 	t.Run("RehttpPool", func(t *testing.T) {
-		initHTTPPool()
+		InitHTTPPool(NewBaseConfiguredHttpClient)
 		cl := GetHTTPClient()
 		clt := cl.Transport
 		PutHTTPClient(cl)


### PR DESCRIPTION
[EVG-19189](https://jira.mongodb.org/browse/EVG-19189)

I'm planning to pass in a client that creates traces for external calls. This PR will allow me to reconfigure the client pool to use the supplied client factory. If you don't configure it it will continue to do the same thing it's doing now.