### PR TITLE
EVG-17142 expose defaults

### DIFF
--- a/http.go
+++ b/http.go
@@ -29,13 +29,17 @@ func initHTTPPool() {
 }
 
 func newBaseConfiguredHttpClient() *http.Client {
+	return DefaultHttpClient(DefaultTransport())
+}
+
+func DefaultHttpClient(rt http.RoundTripper) *http.Client {
 	return &http.Client{
 		Timeout:   httpClientTimeout,
-		Transport: newConfiguredBaseTransport(),
+		Transport: rt,
 	}
 }
 
-func newConfiguredBaseTransport() *http.Transport {
+func DefaultTransport() *http.Transport {
 	return &http.Transport{
 		TLSClientConfig:     &tls.Config{},
 		Proxy:               http.ProxyFromEnvironment,
@@ -76,7 +80,7 @@ func PutHTTPClient(c *http.Client) {
 		PutHTTPClient(c)
 		return
 	default:
-		c.Transport = newConfiguredBaseTransport()
+		c.Transport = DefaultTransport()
 	}
 
 	httpClientPool.Put(c)


### PR DESCRIPTION
[EVG-17142](https://jira.mongodb.org/browse/EVG-17142)

Make the default transport/client public so they can be used in https://github.com/evergreen-ci/evergreen/pull/6677