### PR TITLE
DEVPROD-60: paginated read closer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/PuerkitoBio/rehttp v1.1.0
 	github.com/jpillora/backoff v1.0.0
+	github.com/peterhellberg/link v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/stretchr/testify v1.8.2

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,8 @@ github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/peterhellberg/link v1.2.0 h1:UA5pg3Gp/E0F2WdX7GERiNrPQrM1K6CVJUUWfHa4t6c=
+github.com/peterhellberg/link v1.2.0/go.mod h1:gYfAh+oJgQu2SrZHg5hROVRQe1ICoK0/HHJTcE0edxc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/io.go
+++ b/io.go
@@ -1,6 +1,13 @@
 package utility
 
-import "io"
+import (
+	"context"
+	"io"
+	"net/http"
+
+	"github.com/peterhellberg/link"
+	"github.com/pkg/errors"
+)
 
 type nopWriteCloser struct {
 	io.Writer
@@ -12,4 +19,90 @@ func (nopWriteCloser) Close() error { return nil }
 // the provided writer w.
 func NopWriteCloser(w io.Writer) io.WriteCloser {
 	return nopWriteCloser{w}
+}
+
+type paginatedReadCloser struct {
+	ctx        context.Context
+	client     *http.Client
+	reqHeader  http.Header
+	respHeader http.Header
+
+	io.ReadCloser
+}
+
+// NewPaginatedReadCloser returns an io.ReadCloser implementation for paginated
+// HTTP responses. It is safe to pass in a non-paginated response, thus the
+// caller need not check for the appropriate header keys.
+// GetOptions is used to make any subsequent page requests.
+func NewPaginatedReadCloser(ctx context.Context, client *http.Client, resp *http.Response, reqHeader http.Header) *paginatedReadCloser {
+	return &paginatedReadCloser{
+		ctx:        ctx,
+		client:     client,
+		reqHeader:  reqHeader,
+		respHeader: resp.Header,
+		ReadCloser: resp.Body,
+	}
+}
+
+// Read reads the underlying HTTP response body. Once the body is read, the
+// HTTP response header is used to request the next page, if any. If a
+// subsequent page is successfully requested, the previous body is closed and
+// both the body and header are replaced with the new response. An io.EOF error
+// is returned when the current response body is exhausted and either the
+// response header does not contain a "next" key or the "next" key's URL
+// returns no data.
+func (r *paginatedReadCloser) Read(p []byte) (int, error) {
+	if r.ReadCloser == nil {
+		return 0, io.EOF
+	}
+
+	var (
+		n      int
+		offset int
+		err    error
+	)
+	for offset < len(p) {
+		n, err = r.ReadCloser.Read(p[offset:])
+		offset += n
+		if err == io.EOF {
+			err = r.getNextPage()
+		}
+		if err != nil {
+			break
+		}
+	}
+
+	return offset, err
+}
+
+func (r *paginatedReadCloser) getNextPage() error {
+	group, ok := link.ParseHeader(r.respHeader)["next"]
+	if ok {
+		req, err := http.NewRequestWithContext(r.ctx, http.MethodGet, group.URI, nil)
+		if err != nil {
+			return errors.Wrap(err, "creating http request for next page")
+		}
+		if r.reqHeader != nil {
+			req.Header = r.reqHeader
+		}
+
+		resp, err := r.client.Do(req)
+		if err != nil {
+			return errors.Wrap(err, "requesting next page")
+		}
+		if resp.StatusCode != http.StatusOK {
+			return errors.Errorf("failed to get next page with resp '%s'", resp.Status)
+		}
+
+		if err = r.Close(); err != nil {
+			return errors.Wrap(err, "closing last response reader")
+		}
+
+		r.respHeader = resp.Header
+		r.ReadCloser = resp.Body
+	} else {
+		return io.EOF
+	}
+
+	return nil
 }

--- a/io.go
+++ b/io.go
@@ -32,8 +32,9 @@ type paginatedReadCloser struct {
 
 // NewPaginatedReadCloser returns an io.ReadCloser implementation for paginated
 // HTTP responses. It is safe to pass in a non-paginated response, thus the
-// caller need not check for the appropriate header keys.
-// GetOptions is used to make any subsequent page requests.
+// caller need not check for the appropriate header keys. Optionally pass in
+// a header for subsequent page requests, useful if user information such as
+// API keys are required.
 func NewPaginatedReadCloser(ctx context.Context, client *http.Client, resp *http.Response, reqHeader http.Header) *paginatedReadCloser {
 	return &paginatedReadCloser{
 		ctx:        ctx,

--- a/io_test.go
+++ b/io_test.go
@@ -1,9 +1,17 @@
 package utility
 
 import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNopWriteCloser(t *testing.T) {
@@ -29,4 +37,144 @@ func (w *myWriteCloser) Close() {
 func (w *myWriteCloser) Write(p []byte) (n int, err error) {
 	w.contents = append(w.contents, p...)
 	return 0, nil
+}
+
+func TestPaginatedReadCloser(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	t.Run("PaginatedRoute", func(t *testing.T) {
+		handler := &mockHandler{pages: 3}
+		server := httptest.NewServer(handler)
+		handler.baseURL = server.URL
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, nil)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var r io.ReadCloser
+		r = &paginatedReadCloser{
+			ctx:        ctx,
+			client:     http.DefaultClient,
+			respHeader: resp.Header,
+			ReadCloser: resp.Body,
+		}
+
+		data, err := ioutil.ReadAll(r)
+		require.NoError(t, err)
+		assert.Equal(t, "PAGINATED BODY PAGE 1\nPAGINATED BODY PAGE 2\nPAGINATED BODY PAGE 3\n", string(data))
+		assert.NoError(t, r.Close())
+	})
+	t.Run("PaginatedRouteWithReqHeader", func(t *testing.T) {
+		handler := &mockHandler{headerKeys: []string{"key1", "key2"}, pages: 3}
+		server := httptest.NewServer(handler)
+		handler.baseURL = server.URL
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, nil)
+		require.NoError(t, err)
+		req.Header.Add("key1", "val1")
+		req.Header.Add("key2", "val2")
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var r io.ReadCloser
+		r = &paginatedReadCloser{
+			ctx:        ctx,
+			client:     http.DefaultClient,
+			reqHeader:  req.Header,
+			respHeader: resp.Header,
+			ReadCloser: resp.Body,
+		}
+
+		data, err := ioutil.ReadAll(r)
+		require.NoError(t, err)
+		assert.Equal(t, "HEADER: key1:val1,key2:val2\nPAGINATED BODY PAGE 1\nHEADER: key1:val1,key2:val2\nPAGINATED BODY PAGE 2\nHEADER: key1:val1,key2:val2\nPAGINATED BODY PAGE 3\n", string(data))
+		assert.NoError(t, r.Close())
+	})
+	t.Run("NonPaginatedRoute", func(t *testing.T) {
+		handler := &mockHandler{}
+		server := httptest.NewServer(handler)
+		handler.baseURL = server.URL
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, nil)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var r io.ReadCloser
+		r = &paginatedReadCloser{
+			ctx:        ctx,
+			client:     http.DefaultClient,
+			respHeader: resp.Header,
+			ReadCloser: resp.Body,
+		}
+
+		data, err := ioutil.ReadAll(r)
+		require.NoError(t, err)
+		assert.Equal(t, "NON-PAGINATED BODY PAGE", string(data))
+		assert.NoError(t, r.Close())
+	})
+	t.Run("SplitPageByteSlice", func(t *testing.T) {
+		handler := &mockHandler{pages: 2}
+		server := httptest.NewServer(handler)
+		handler.baseURL = server.URL
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, nil)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var r io.ReadCloser
+		r = &paginatedReadCloser{
+			ctx:        ctx,
+			client:     http.DefaultClient,
+			respHeader: resp.Header,
+			ReadCloser: resp.Body,
+		}
+
+		p := make([]byte, 33) // 1.5X len of each page
+		n, err := r.Read(p)
+		require.NoError(t, err)
+		assert.Equal(t, len(p), n)
+		assert.Equal(t, "PAGINATED BODY PAGE 1\nPAGINATED B", string(p))
+		p = make([]byte, 33)
+		n, err = r.Read(p)
+		require.Equal(t, io.EOF, err)
+		assert.Equal(t, 11, n)
+		assert.Equal(t, "ODY PAGE 2\n", string(p[:11]))
+		assert.NoError(t, r.Close())
+	})
+}
+
+type mockHandler struct {
+	baseURL    string
+	headerKeys []string
+	pages      int
+	count      int
+}
+
+func (h *mockHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if h.pages > 0 {
+		if h.count <= h.pages-1 {
+			w.Header().Set("Link", fmt.Sprintf("<%s>; rel=\"%s\"", h.baseURL, "next"))
+
+			if len(h.headerKeys) > 0 {
+				var headerPairs []string
+				for _, headerKey := range h.headerKeys {
+					headerPairs = append(headerPairs, fmt.Sprintf("%s:%s", headerKey, r.Header.Get(headerKey)))
+				}
+				_, _ = w.Write([]byte(fmt.Sprintf("HEADER: %s\n", strings.Join(headerPairs, ","))))
+			}
+
+			_, _ = w.Write([]byte(fmt.Sprintf("PAGINATED BODY PAGE %d\n", h.count+1)))
+		}
+		h.count++
+	} else {
+		_, _ = w.Write([]byte("NON-PAGINATED BODY PAGE"))
+	}
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/DEVPROD-60

To facilitate fetching paginated logs via the CLI, it is convenient to have a paginated reader that fetches subsequent pages automatically. This change essentially copies the [paginated reader from timber](https://github.com/evergreen-ci/timber/blob/main/paginated_reader.go) over.