### PR TITLE
DEVPROD-9391: create helper for making slice batches

### DIFF
--- a/slice.go
+++ b/slice.go
@@ -177,3 +177,25 @@ func StringSliceContainsOrderedPrefixSubset(superset, subset []string) bool {
 		return strings.HasPrefix(a, b)
 	})
 }
+
+// SliceBatches partitions the elems slice into batches with at most
+// maxElemsPerBatch in each batch. If maxElemsPerBatch is not a positive
+// integer, it will make batches of size 1.
+func MakeSliceBatches[T any](elems []T, maxElemsPerBatch int) [][]T {
+	if len(elems) == 0 {
+		return nil
+	}
+	if maxElemsPerBatch <= 0 {
+		maxElemsPerBatch = 1
+	}
+
+	remainingElems := elems
+	var batches [][]T
+	for len(remainingElems) > maxElemsPerBatch {
+		batches = append(batches, remainingElems[0:maxElemsPerBatch:maxElemsPerBatch])
+		remainingElems = remainingElems[maxElemsPerBatch:]
+	}
+	batches = append(batches, remainingElems)
+
+	return batches
+}


### PR DESCRIPTION
[DEVPROD-9391](https://jira.mongodb.org/browse/DEVPROD-9391)

From https://github.com/evergreen-ci/evergreen/pull/8178#discussion_r1714132423

Copied over the tests and batching implementation.