### PR TITLE
DEVPROD-7885 Add retryable option for invalid body to RetryRequest

### DIFF
--- a/http.go
+++ b/http.go
@@ -318,6 +318,9 @@ func IsTemporaryError(err error) bool {
 	return false
 }
 
+// RetryRequestOptions specifically are the options when doing
+// a retryable request. It wraps the RetryOptions and adds options
+// on top that are specific to requests.
 type RetryRequestOptions struct {
 	RetryOptions
 


### PR DESCRIPTION
[DEVPROD-7885](https://jira.mongodb.org/browse/DEVPROD-7885)

This adds a retry option for invalid bodies in the RetryRequest. This is to support cases where when reading from the body gives an unexpected EOF.