### PR TITLE
DEVPROD-3611: upgrade Go version

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,7 @@ linters:
   disable-all: true
   enable:
     - errcheck
+    - gofmt
     - goimports
     - govet
     - ineffassign

--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -85,7 +85,7 @@ buildvariants:
   - name: lint
     display_name: Lint
     expansions:
-      GOROOT: /opt/golang/go1.20
+      GOROOT: /opt/golang/go1.24
     run_on:
       - ubuntu2204-small
       - ubuntu2204-large
@@ -95,7 +95,7 @@ buildvariants:
   - name: ubuntu
     display_name: Ubuntu 22.04
     expansions:
-      GOROOT: /opt/golang/go1.20
+      GOROOT: /opt/golang/go1.24
     run_on:
       - ubuntu2204-small
       - ubuntu2204-large

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/evergreen-ci/utility
 
-go 1.20
+go 1.24
 
 require (
 	github.com/PuerkitoBio/rehttp v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,7 @@ github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=

--- a/http_test.go
+++ b/http_test.go
@@ -113,8 +113,8 @@ func TestMockHandler(t *testing.T) {
 	t.Run("Serve", func(t *testing.T) {
 		urlString := server.URL + "/example"
 		handler.Header = map[string][]string{
-			"header1": []string{"header1"},
-			"header2": []string{"header1", "header2"},
+			"header1": {"header1"},
+			"header2": {"header1", "header2"},
 		}
 		handler.Body = []byte("some body")
 		handler.StatusCode = http.StatusOK
@@ -136,7 +136,7 @@ func TestMockHandler(t *testing.T) {
 
 		urlString = server.URL + "/example2"
 		handler.Header = map[string][]string{
-			"header1": []string{"header1"},
+			"header1": {"header1"},
 		}
 		handler.Body = []byte("example not found")
 		handler.StatusCode = http.StatusNotFound

--- a/makefile
+++ b/makefile
@@ -62,7 +62,7 @@ $(shell mkdir -p $(buildDir))
 
 # start lint setup targets
 $(buildDir)/golangci-lint:
-	@curl --retry 10 --retry-max-time 60 -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(buildDir) v1.52.2 >/dev/null 2>&1
+	@curl --retry 10 --retry-max-time 60 -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(buildDir) v1.64.5 >/dev/null 2>&1
 $(buildDir)/run-linter: cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
 	@$(gobin) build -o $@ $<
 # end lint setup targets


### PR DESCRIPTION
[DEVPROD-3611](https://jira.mongodb.org/browse/DEVPROD-3611)

* Upgrade to Go 1.24.
* Upgrade golangci-lint to support Go 1.24.
* Remove some old linters that are now invalid.
* Fix `gofmt` lint issues.