### PR TITLE
[DRAFT] feat: add weak cache

### DIFF
--- a/ttlcache/weak.go
+++ b/ttlcache/weak.go
@@ -1,0 +1,36 @@
+package cache
+
+import (
+	"context"
+	"time"
+	"weak"
+)
+
+func NewWeakInMemory[T any]() *WeakInMemory[T] {
+	return &WeakInMemory[T]{
+		cache: NewTTLInMemory[weak.Pointer[T]](),
+	}
+}
+
+type WeakInMemory[T any] struct {
+	cache *TTLInMemoryCache[weak.Pointer[T]]
+}
+
+func (w *WeakInMemory[T]) Get(ctx context.Context, id string, minimumLifetime time.Duration) (T, bool) {
+	weakVal, found := w.cache.Get(ctx, id, minimumLifetime)
+	if !found {
+		var zero T
+		return zero, false
+	}
+	val := weakVal.Value()
+	if val == nil {
+		var zero T
+		return zero, false
+	}
+
+	return *val, true
+}
+
+func (w *WeakInMemory[T]) Put(ctx context.Context, id string, value T, expiresAt time.Time) {
+	w.cache.Put(ctx, id, weak.Make(&value), expiresAt)
+}

--- a/ttlcache/weak.go
+++ b/ttlcache/weak.go
@@ -1,4 +1,4 @@
-package cache
+package ttlcache
 
 import (
 	"context"
@@ -6,14 +6,15 @@ import (
 	"weak"
 )
 
+// NewWeakInMemory creates a new thread-safe in-memory ttl cache that uses weak references.
 func NewWeakInMemory[T any]() *WeakInMemory[T] {
 	return &WeakInMemory[T]{
-		cache: NewTTLInMemory[weak.Pointer[T]](),
+		cache: NewInMemory[weak.Pointer[T]](),
 	}
 }
 
 type WeakInMemory[T any] struct {
-	cache *TTLInMemoryCache[weak.Pointer[T]]
+	cache *InMemoryCache[weak.Pointer[T]]
 }
 
 func (w *WeakInMemory[T]) Get(ctx context.Context, id string, minimumLifetime time.Duration) (T, bool) {

--- a/ttlcache/weak_test.go
+++ b/ttlcache/weak_test.go
@@ -1,0 +1,11 @@
+package ttlcache
+
+import (
+	"testing"
+)
+
+func TestWeakInMemory(t *testing.T) {
+	testCache(t, func() Cache[int] {
+		return NewWeakInMemory[int]()
+	})
+}


### PR DESCRIPTION
Will add tests after #76 is merged.

I thought of an idea to use deduplicate some Find queries we do. We often do some queries that load or set data, then later in the same execution/goroutine/request, we do a Find query that effectively just gets the same information that was already found or set.

Instead of immediately doing a Find query, we can check a cache that's stored inside the context. This cache should be a weak pointer cache, so it does not stop garbage collection of the items it references. If the cache finds the item, we've saved a query. If it doesn't, we query as usual. To prevent stale data, we can set the lifetime of objects added to the cache as a low time, something like 5 seconds. This would allow for requests that take long, but not make the data risky to race conditions.