### PR TITLE
DEVPROD-12908 Add weak cache implementation

### DIFF
--- a/ttlcache/weak.go
+++ b/ttlcache/weak.go
@@ -1,0 +1,36 @@
+package cache
+
+import (
+	"context"
+	"time"
+	"weak"
+)
+
+func NewWeakInMemory[T any]() *WeakInMemory[T] {
+	return &WeakInMemory[T]{
+		cache: NewTTLInMemory[weak.Pointer[T]](),
+	}
+}
+
+type WeakInMemory[T any] struct {
+	cache *TTLInMemoryCache[weak.Pointer[T]]
+}
+
+func (w *WeakInMemory[T]) Get(ctx context.Context, id string, minimumLifetime time.Duration) (T, bool) {
+	weakVal, found := w.cache.Get(ctx, id, minimumLifetime)
+	if !found {
+		var zero T
+		return zero, false
+	}
+	val := weakVal.Value()
+	if val == nil {
+		var zero T
+		return zero, false
+	}
+
+	return *val, true
+}
+
+func (w *WeakInMemory[T]) Put(ctx context.Context, id string, value T, expiresAt time.Time) {
+	w.cache.Put(ctx, id, weak.Make(&value), expiresAt)
+}

--- a/ttlcache/weak.go
+++ b/ttlcache/weak.go
@@ -1,4 +1,4 @@
-package cache
+package ttlcache
 
 import (
 	"context"
@@ -6,14 +6,15 @@ import (
 	"weak"
 )
 
+// NewWeakInMemory creates a new thread-safe in-memory ttl cache that uses weak references.
 func NewWeakInMemory[T any]() *WeakInMemory[T] {
 	return &WeakInMemory[T]{
-		cache: NewTTLInMemory[weak.Pointer[T]](),
+		cache: NewInMemory[weak.Pointer[T]](),
 	}
 }
 
 type WeakInMemory[T any] struct {
-	cache *TTLInMemoryCache[weak.Pointer[T]]
+	cache *InMemoryCache[weak.Pointer[T]]
 }
 
 func (w *WeakInMemory[T]) Get(ctx context.Context, id string, minimumLifetime time.Duration) (T, bool) {

--- a/ttlcache/weak_test.go
+++ b/ttlcache/weak_test.go
@@ -1,0 +1,11 @@
+package ttlcache
+
+import (
+	"testing"
+)
+
+func TestWeakInMemory(t *testing.T) {
+	testCache(t, func() Cache[int] {
+		return NewWeakInMemory[int]()
+	})
+}


### PR DESCRIPTION
DEVPROD-12908

### Description
The ticket is to optimize some GitHub calls, I want to add a cache layer above them. One issue with this currently the cache doesn't get flushed (except when we start/stop the app servers). So if we store large objects, they'll float around in memory the whole time. This adds a weak cache implementation to ensure those values don't float around _because_ of the cache and will be picked up by GC. This works out well since most tasks run around the same time, so as they get used from the cache it will 'refresh' them in the cache.