### PR TITLE
DEVPROD-16412: add method to append attributes to context

### DIFF
--- a/otel.go
+++ b/otel.go
@@ -34,10 +34,20 @@ func (processor *attributeSpanProcessor) Shutdown(context.Context) error { retur
 // ForceFlush is a noop to satisfy the SpanProcessor interface.
 func (processor *attributeSpanProcessor) ForceFlush(context.Context) error { return nil }
 
-// ContextWithAttributes returns a child of the ctx containing the attributes. All spans
-// created with the returned context and its children will have the attributes set.
+// ContextWithAttributes returns a child of the ctx containing the attributes.
+// All spans created with the returned context and its children will have the
+// attributes set. If there are any existing attributes on the context already,
+// the returned child context will override all of the existing attributes.
 func ContextWithAttributes(ctx context.Context, attributes []attribute.KeyValue) context.Context {
 	return context.WithValue(ctx, otelAttributeContextKey, attributes)
+}
+
+// AppendAttributesToContext is the same as ContextWithAttributes but creates a
+// child context that appends the provided attributes to the existing attributes
+// in the context (if there are any) rather than overriding them.
+func AppendAttributesToContext(ctx context.Context, toAppend []attribute.KeyValue) context.Context {
+	combined := append(attributesFromContext(ctx), toAppend...)
+	return ContextWithAttributes(ctx, combined)
 }
 
 func attributesFromContext(ctx context.Context) []attribute.KeyValue {

--- a/otel.go
+++ b/otel.go
@@ -42,10 +42,10 @@ func ContextWithAttributes(ctx context.Context, attributes []attribute.KeyValue)
 	return context.WithValue(ctx, otelAttributeContextKey, attributes)
 }
 
-// AppendAttributesToContext is the same as ContextWithAttributes but creates a
-// child context that appends the provided attributes to the existing attributes
-// in the context (if there are any) rather than overriding them.
-func AppendAttributesToContext(ctx context.Context, toAppend []attribute.KeyValue) context.Context {
+// ContextWithAppendedAttributes is the same as ContextWithAttributes but
+// creates a child context that appends the provided attributes to the existing
+// attributes in the context (if there are any) rather than overriding them.
+func ContextWithAppendedAttributes(ctx context.Context, toAppend []attribute.KeyValue) context.Context {
 	combined := append(attributesFromContext(ctx), toAppend...)
 	return ContextWithAttributes(ctx, combined)
 }

--- a/otel_test.go
+++ b/otel_test.go
@@ -1,0 +1,74 @@
+package utility
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func TestContextWithAttributes(t *testing.T) {
+	t.Run("HasNoInitialAttributes", func(t *testing.T) {
+		ctx := context.Background()
+		assert.Empty(t, attributesFromContext(ctx))
+	})
+	t.Run("HasNoAttributesWhenAddingNil", func(t *testing.T) {
+		ctx := ContextWithAttributes(context.Background(), nil)
+		assert.Empty(t, attributesFromContext(ctx))
+	})
+	t.Run("HasAttributesAfterSetting", func(t *testing.T) {
+		attrs := []attribute.KeyValue{
+			attribute.String("key1", "value1"),
+			attribute.Int("key2", 42),
+		}
+		ctx := ContextWithAttributes(context.Background(), attrs)
+		assert.Equal(t, attrs, attributesFromContext(ctx))
+
+		childCtx := context.WithValue(ctx, "unrelatedContextKey", "unrelatedContextValue")
+		assert.Equal(t, attrs, attributesFromContext(childCtx), "child context should inherit span attributes from parent")
+	})
+	t.Run("OverwritesExistingAttributes", func(t *testing.T) {
+		oldAttrs := []attribute.KeyValue{
+			attribute.String("oldKey", "oldValue"),
+		}
+		ctx := ContextWithAttributes(context.Background(), oldAttrs)
+		assert.Equal(t, oldAttrs, attributesFromContext(ctx))
+
+		newAttrs := []attribute.KeyValue{
+			attribute.String("newKey", "newValue"),
+		}
+		newCtx := ContextWithAttributes(ctx, newAttrs)
+		assert.Equal(t, newAttrs, attributesFromContext(newCtx), "new context should have overwritten old attributes")
+		assert.Equal(t, oldAttrs, attributesFromContext(ctx), "original context attributes should remain unchanged")
+	})
+}
+
+func TestAppendAttributesToContext(t *testing.T) {
+	t.Run("AppendsToInitiallyEmptyContext", func(t *testing.T) {
+		attrs := []attribute.KeyValue{
+			attribute.String("key1", "value1"),
+			attribute.Int("key2", 42),
+		}
+		ctx := AppendAttributesToContext(context.Background(), attrs)
+		assert.Equal(t, attrs, attributesFromContext(ctx))
+
+		childCtx := context.WithValue(ctx, "unrelatedContextKey", "unrelatedContextValue")
+		assert.Equal(t, attrs, attributesFromContext(childCtx), "child context should inherit span attributes from parent")
+	})
+	t.Run("AppendsToContextWithPreexistingAttributes", func(t *testing.T) {
+		oldAttrs := []attribute.KeyValue{
+			attribute.String("oldKey", "oldValue"),
+		}
+		oldCtx := AppendAttributesToContext(context.Background(), oldAttrs)
+		assert.Equal(t, oldAttrs, attributesFromContext(oldCtx))
+
+		newAttrs := []attribute.KeyValue{
+			attribute.String("newKey", "newValue"),
+		}
+		newCtx := AppendAttributesToContext(oldCtx, newAttrs)
+		expectedAttrs := append(oldAttrs, newAttrs...)
+		assert.Equal(t, expectedAttrs, attributesFromContext(newCtx), "new context should have both previous and newly-added attributes")
+		assert.Equal(t, oldAttrs, attributesFromContext(oldCtx), "original context attributes should remain unchanged")
+	})
+}

--- a/otel_test.go
+++ b/otel_test.go
@@ -50,7 +50,7 @@ func TestAppendAttributesToContext(t *testing.T) {
 			attribute.String("key1", "value1"),
 			attribute.Int("key2", 42),
 		}
-		ctx := AppendAttributesToContext(context.Background(), attrs)
+		ctx := ContextWithAppendedAttributes(context.Background(), attrs)
 		assert.Equal(t, attrs, attributesFromContext(ctx))
 
 		childCtx := context.WithValue(ctx, "unrelatedContextKey", "unrelatedContextValue")
@@ -60,13 +60,13 @@ func TestAppendAttributesToContext(t *testing.T) {
 		oldAttrs := []attribute.KeyValue{
 			attribute.String("oldKey", "oldValue"),
 		}
-		oldCtx := AppendAttributesToContext(context.Background(), oldAttrs)
+		oldCtx := ContextWithAppendedAttributes(context.Background(), oldAttrs)
 		assert.Equal(t, oldAttrs, attributesFromContext(oldCtx))
 
 		newAttrs := []attribute.KeyValue{
 			attribute.String("newKey", "newValue"),
 		}
-		newCtx := AppendAttributesToContext(oldCtx, newAttrs)
+		newCtx := ContextWithAppendedAttributes(oldCtx, newAttrs)
 		expectedAttrs := append(oldAttrs, newAttrs...)
 		assert.Equal(t, expectedAttrs, attributesFromContext(newCtx), "new context should have both previous and newly-added attributes")
 		assert.Equal(t, oldAttrs, attributesFromContext(oldCtx), "original context attributes should remain unchanged")


### PR DESCRIPTION
[DEVPROD-16412](https://jira.mongodb.org/browse/DEVPROD-16412)

### Description
`ContextWithAttributes` always overrides any pre-existing attributes when it creates the child context. But in some cases, we want to iteratively add more attributes to the same context rather than throwing out the previous attributes that have already been added. I added a method to make it easier to append rather than override the attributes associated with the context.

### Testing
Added unit tests.