### PR TITLE
DEVPROD-26606 Add convertInt32PtrToIntPtr

### DIFF
--- a/conversion.go
+++ b/conversion.go
@@ -2,8 +2,8 @@ package utility
 
 // This file includes type conversion functions.
 
-// convertInt32PtrToIntPtr converts *int32 to *int.
-func convertInt32PtrToIntPtr(i32 *int32) *int {
+// ConvertInt32PtrToIntPtr converts *int32 to *int.
+func ConvertInt32PtrToIntPtr(i32 *int32) *int {
 	if i32 == nil {
 		return nil
 	}

--- a/conversion.go
+++ b/conversion.go
@@ -1,0 +1,12 @@
+package utility
+
+// This file includes type conversion functions.
+
+// convertInt32PtrToIntPtr converts *int32 to *int.
+func convertInt32PtrToIntPtr(i32 *int32) *int {
+	if i32 == nil {
+		return nil
+	}
+	i := int(*i32)
+	return &i
+}


### PR DESCRIPTION
[DEVPROD-26606](https://jira.mongodb.org/browse/DEVPROD-26606)

This adds a function that will be needed by [DEVPROD-26405](https://jira.mongodb.org/browse/DEVPROD-26405). I didn't put it with `FromStringPtr`, `ToStringPtr`, etc since those are in optional.go which is meant for conversion functions for using pointers as optional values. This function converts from one pointer type to another, which is more of a general type conversion utility. Instead I created a `conversion.go` for it.  