### PR TITLE
DEVPROD-32356 Add on retry callback

### DIFF
--- a/http.go
+++ b/http.go
@@ -341,7 +341,7 @@ type RetryRequestOptions struct {
 	// the server returns a 413 status code.
 	RetryOn413 bool
 
-	// OnRetry is an optional callback ran after each failed attempt.
+	// OnRetry is an optional callback ran after each failed attempt that will be retried.
 	OnRetry func(FailedAttempt)
 }
 

--- a/http.go
+++ b/http.go
@@ -318,6 +318,15 @@ func IsTemporaryError(err error) bool {
 	return false
 }
 
+// FailedAttempt holds information about a single failed request attempt.
+type FailedAttempt struct {
+	Attempt  int
+	Delay    time.Duration
+	Request  *http.Request
+	Response *http.Response
+	Err      error
+}
+
 // RetryRequestOptions specifically are the options when doing
 // a retryable request. It wraps the RetryOptions and adds options
 // on top that are specific to requests.
@@ -331,6 +340,9 @@ type RetryRequestOptions struct {
 	// RetryOn413 is a flag that determines whether to retry when
 	// the server returns a 413 status code.
 	RetryOn413 bool
+
+	// OnRetry is an optional callback ran after each failed attempt.
+	OnRetry func(FailedAttempt)
 }
 
 // RetryRequest takes an http.Request and makes the request until it's successful,
@@ -352,6 +364,19 @@ func RetryRequest(ctx context.Context, r *http.Request, opts RetryRequestOptions
 	client := GetDefaultHTTPRetryableClient()
 	defer PutHTTPClient(client)
 
+	hookBackoff := getBackoff(opts.RetryOptions)
+	fireOnRetry := func(attempt int, failedResp *http.Response, err error) {
+		if opts.OnRetry != nil {
+			opts.OnRetry(FailedAttempt{
+				Attempt:  attempt,
+				Delay:    hookBackoff.Duration(),
+				Request:  r,
+				Response: failedResp,
+				Err:      err,
+			})
+		}
+	}
+
 	attempt := 1
 	var resp *http.Response
 	var err error
@@ -368,6 +393,7 @@ func RetryRequest(ctx context.Context, r *http.Request, opts RetryRequestOptions
 
 		resp, err = client.Do(r)
 		if err != nil {
+			fireOnRetry(attempt, nil, err)
 			return true, err
 		}
 
@@ -378,6 +404,7 @@ func RetryRequest(ctx context.Context, r *http.Request, opts RetryRequestOptions
 				// Test if the body is valid by reading it.
 				body := &bytes.Buffer{}
 				if _, err := body.ReadFrom(resp.Body); err != nil {
+					fireOnRetry(attempt, resp, err)
 					return true, err
 				}
 
@@ -388,7 +415,9 @@ func RetryRequest(ctx context.Context, r *http.Request, opts RetryRequestOptions
 		}
 
 		if resp.StatusCode == http.StatusRequestEntityTooLarge && opts.RetryOn413 {
-			return true, errors.Errorf("server returned status %d (request entity too large)", resp.StatusCode)
+			retryErr := errors.Errorf("server returned status %d (request entity too large)", resp.StatusCode)
+			fireOnRetry(attempt, resp, retryErr)
+			return true, retryErr
 		}
 
 		if resp.StatusCode >= 400 && resp.StatusCode < 500 {
@@ -396,8 +425,9 @@ func RetryRequest(ctx context.Context, r *http.Request, opts RetryRequestOptions
 		}
 
 		// if we get here it should most likely be a 5xx status code
-
-		return true, errors.Errorf("server returned status %d", resp.StatusCode)
+		retryErr := errors.Errorf("server returned status %d", resp.StatusCode)
+		fireOnRetry(attempt, resp, retryErr)
+		return true, retryErr
 	}, opts.RetryOptions); err != nil {
 		return resp, err
 	}

--- a/http_test.go
+++ b/http_test.go
@@ -252,7 +252,7 @@ func TestRetryRequestOnRetry(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		}
 	}))
-	defer server.Close()
+	t.Cleanup(server.Close)
 
 	var hookCalls []FailedAttempt
 	opts := RetryRequestOptions{
@@ -269,7 +269,7 @@ func TestRetryRequestOnRetry(t *testing.T) {
 	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
 	require.NoError(t, err)
 
-	resp, err := RetryRequest(context.Background(), req, opts)
+	resp, err := RetryRequest(t.Context(), req, opts)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 

--- a/http_test.go
+++ b/http_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/PuerkitoBio/rehttp"
 	"github.com/stretchr/testify/assert"
@@ -240,4 +241,41 @@ func TestRetryRequestBodyRemainsValidOnSecondAttempt(t *testing.T) {
 	// The second attempt should contain the original request body text:
 	assert.Contains(t, string(data), "request body data", "expected second attempt to see same request body")
 
+}
+
+func TestRetryRequestOnRetry(t *testing.T) {
+	var serverCalls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&serverCalls, 1) == 1 {
+			w.WriteHeader(http.StatusRequestEntityTooLarge)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	var hookCalls []FailedAttempt
+	opts := RetryRequestOptions{
+		RetryOptions: RetryOptions{
+			MaxAttempts: 3,
+			MinDelay:    10 * time.Millisecond,
+		},
+		RetryOn413: true,
+		OnRetry: func(fa FailedAttempt) {
+			hookCalls = append(hookCalls, fa)
+		},
+	}
+
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := RetryRequest(context.Background(), req, opts)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	require.Len(t, hookCalls, 1)
+	assert.Equal(t, 1, hookCalls[0].Attempt)
+	assert.Greater(t, hookCalls[0].Delay, time.Duration(0))
+	assert.NotNil(t, hookCalls[0].Response)
+	assert.NotNil(t, hookCalls[0].Err)
 }


### PR DESCRIPTION
[DEVPROD-32356](https://jira.mongodb.org/browse/DEVPROD-32356)

### Description

This adds a retry callback to the http retry request func. This is specifically so we can log the retries on the agent to provide some visibility in test logs.