### PR TITLE
DEVPROD-37017: add optional wrapper for OTel instrumentation

### DIFF
--- a/http.go
+++ b/http.go
@@ -32,14 +32,7 @@ func initHTTPPool() {
 }
 
 func newBaseConfiguredHttpClient() *http.Client {
-	return DefaultHttpClient(newOTelTransport())
-}
-
-// newOTelTransport returns the default transport wrapped in otelhttp
-// instrumentation so that a span is created for each request that goes over the
-// wire.
-func newOTelTransport() http.RoundTripper {
-	return otelhttp.NewTransport(DefaultTransport())
+	return DefaultHttpClient(DefaultTransport())
 }
 
 func DefaultHttpClient(rt http.RoundTripper) *http.Client {
@@ -67,6 +60,26 @@ func DefaultTransport() *http.Transport {
 
 }
 
+// otelTransport is an http.RoundTripper with OTel instrumentation.
+type otelTransport struct {
+	base         http.RoundTripper
+	instrumented *otelhttp.Transport
+}
+
+func (t *otelTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	return t.instrumented.RoundTrip(r)
+}
+
+// WithOTelTracing wraps the client's transport with OTel instrumentation so
+// that a span is created for each request the client makes.
+func WithOTelTracing(c *http.Client) *http.Client {
+	c.Transport = &otelTransport{
+		base:         c.Transport,
+		instrumented: otelhttp.NewTransport(c.Transport),
+	}
+	return c
+}
+
 // GetHTTPClient produces default HTTP client from the pool,
 // constructing a new client if needed. Always pair calls to
 // GetHTTPClient with defered calls to PutHTTPClient.
@@ -77,10 +90,14 @@ func GetHTTPClient() *http.Client { return httpClientPool.Get().(*http.Client) }
 func PutHTTPClient(c *http.Client) {
 	c.Timeout = httpClientTimeout
 
+	// Unwrap any transport wrappers so that the client is returned to the pool
+	// in a clean state.
 	switch transport := c.Transport.(type) {
-	case *otelhttp.Transport, *http.Transport:
-		// These are the base pooled transports, so return the client to
-		// the pool as-is.
+	case *http.Transport:
+	case *otelTransport:
+		c.Transport = transport.base
+		PutHTTPClient(c)
+		return
 	case *rehttp.Transport:
 		c.Transport = transport.RoundTripper
 		PutHTTPClient(c)
@@ -90,7 +107,7 @@ func PutHTTPClient(c *http.Client) {
 		PutHTTPClient(c)
 		return
 	default:
-		c.Transport = newOTelTransport()
+		c.Transport = DefaultTransport()
 	}
 
 	httpClientPool.Put(c)

--- a/http_test.go
+++ b/http_test.go
@@ -1,7 +1,6 @@
 package utility
 
 import (
-	"context"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -13,33 +12,83 @@ import (
 	"github.com/PuerkitoBio/rehttp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"golang.org/x/oauth2"
 )
 
 func TestPooledHTTPClient(t *testing.T) {
-	t.Run("Initialized", func(t *testing.T) {
-		require.NotNil(t, httpClientPool)
-		cl := GetHTTPClient()
-		require.NotNil(t, cl)
-		require.NotPanics(t, func() { PutHTTPClient(cl) })
-	})
-	t.Run("HasOTelInstrumentation", func(t *testing.T) {
-		cl := GetHTTPClient()
-		defer PutHTTPClient(cl)
-		_, ok := cl.Transport.(*otelhttp.Transport)
-		assert.True(t, ok, "pooled client should be wrapped with otelhttp instrumentation")
-	})
-	t.Run("RehttpPool", func(t *testing.T) {
-		initHTTPPool()
-		cl := GetHTTPClient()
-		clt := cl.Transport
-		PutHTTPClient(cl)
-		rcl := GetDefaultHTTPRetryableClient()
-		assert.Equal(t, cl, rcl)
-		assert.NotEqual(t, clt, rcl.Transport)
-		assert.Equal(t, clt, rcl.Transport.(*rehttp.Transport).RoundTripper)
-	})
+	t.Cleanup(initHTTPPool)
+	for testName, testCase := range map[string]func(t *testing.T){
+		"Initialized": func(t *testing.T) {
+			require.NotNil(t, httpClientPool)
+			cl := GetHTTPClient()
+			require.NotNil(t, cl)
+			require.NotPanics(t, func() { PutHTTPClient(cl) })
+		},
+		"RehttpPool": func(t *testing.T) {
+			cl := GetHTTPClient()
+			clt := cl.Transport
+			PutHTTPClient(cl)
+			rcl := GetDefaultHTTPRetryableClient()
+			assert.Equal(t, cl, rcl)
+			assert.NotEqual(t, clt, rcl.Transport)
+			assert.Equal(t, clt, rcl.Transport.(*rehttp.Transport).RoundTripper)
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			initHTTPPool()
+			testCase(t)
+		})
+	}
+}
+
+func TestWithOTelTracing(t *testing.T) {
+	t.Cleanup(initHTTPPool)
+	for testName, testCase := range map[string]func(t *testing.T){
+		"CreatesSpanForRequest": func(t *testing.T) {
+			recorder := tracetest.NewSpanRecorder()
+			provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+			originalProvider := otel.GetTracerProvider()
+			otel.SetTracerProvider(provider)
+			defer otel.SetTracerProvider(originalProvider)
+
+			srv := httptest.NewServer(NewMockHandler())
+			defer srv.Close()
+
+			cl := WithOTelTracing(GetHTTPClient())
+			defer PutHTTPClient(cl)
+
+			resp, err := cl.Get(srv.URL)
+			require.NoError(t, err)
+			require.NoError(t, resp.Body.Close())
+
+			require.NoError(t, provider.ForceFlush(t.Context()))
+			assert.Len(t, recorder.Ended(), 1, "should have one ended span at the end of one request")
+		},
+		"UnwrapsInstrumentationWhenReturnedToPool": func(t *testing.T) {
+			cl := WithOTelTracing(GetHTTPClient())
+			require.IsType(t, &otelTransport{}, cl.Transport)
+
+			PutHTTPClient(cl)
+
+			assert.IsType(t, &http.Transport{}, GetHTTPClient().Transport, "OTel-wrapped transport should be unwrapped when returned to pool")
+		},
+		"UnwrapsInstrumentationLayeredWithRetryableClient": func(t *testing.T) {
+			cl := WithOTelTracing(GetDefaultHTTPRetryableClient())
+			require.IsType(t, &otelTransport{}, cl.Transport)
+
+			PutHTTPClient(cl)
+
+			assert.IsType(t, &http.Transport{}, GetHTTPClient().Transport, "multiple transport wrappers should be fully unwrapped when returned to pool")
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			initHTTPPool()
+			testCase(t)
+		})
+	}
 }
 
 type mockTransport struct {
@@ -130,7 +179,7 @@ func TestRetryRequestOn413(t *testing.T) {
 	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
 	require.NoError(t, err, "failed to create request")
 
-	resp, err := RetryRequest(context.Background(), req, opts)
+	resp, err := RetryRequest(t.Context(), req, opts)
 	require.NoError(t, err, "request failed")
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode, "expected 200 status code")
@@ -225,7 +274,7 @@ func TestRetryRequestBodyRemainsValidOnSecondAttempt(t *testing.T) {
 	req, err := http.NewRequest(http.MethodPost, server.URL, strings.NewReader("request body data"))
 	require.NoError(t, err, "failed to create request")
 
-	resp, err := RetryRequest(context.Background(), req, opts)
+	resp, err := RetryRequest(t.Context(), req, opts)
 	require.NoError(t, err, "request failed")
 	defer resp.Body.Close()
 


### PR DESCRIPTION
[DEVPROD-37017](https://jira.mongodb.org/browse/DEVPROD-37017)

Slightly change #85 so instead of automatically adding OTel instrumentation to all HTTP clients from the pool, callers have an option to wrap the client in OTel instrumentation if they so choose.  Most callers probably will want the OTel wrapper, but making it an explicit choice is slightly safer in case the caller knows that their client will make a lot of requests (since 1 request = 1 new span).

### Testing
Added unit tests.